### PR TITLE
Make 2FA input type number

### DIFF
--- a/templates/default/twofactorauth/login.tpl.php
+++ b/templates/default/twofactorauth/login.tpl.php
@@ -18,7 +18,7 @@
                 <div class="controls">
                    
 		    <p>This account requires Two Factor Authentication, please use a tool such as Google Authenticator to generate your access code:</p>
-		    <input type="text" id="input2FA" name="2fa" placeholder="2fa Code" autofocus>
+		    <input type="number" id="input2FA" name="2fa" placeholder="2fa Code" autofocus>
 		    
                 </div>
             </div>


### PR DESCRIPTION
Switches mobile browsers to a keyboard where digits prominent; helps when you do not want to overwrite your clipboard